### PR TITLE
Fix Hover Effect Not Working In Production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "astro": "^4.16.11",
+        "moving-faces": "file:",
         "sass": "^1.80.7",
         "typescript": "^5.6.3"
       }
@@ -4640,6 +4641,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/moving-faces": {
+      "resolved": "",
+      "link": true
     },
     "node_modules/mrmime": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "astro": "^4.16.11",
+    "moving-faces": "file:",
     "sass": "^1.80.7",
     "typescript": "^5.6.3"
   }

--- a/public/scripts/hoverEffect.js
+++ b/public/scripts/hoverEffect.js
@@ -1,4 +1,4 @@
-import { faces } from '../../src/data/faces'
+const faces = window.facesData
 
 // Get all the face nodes(img)
 const facePhotos = document.querySelectorAll('.faceCard img')

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,6 +22,9 @@ import Layout from '../layouts/Layout.astro'
     <footer>That's All 🙂</footer>
   </main>
 
+  <script is:inline type="module" define:vars={{ faces }}>
+    window.facesData = faces
+  </script>
   <script is:inline src="/scripts/hoverEffect.js" type="module"></script>
 </Layout>
 


### PR DESCRIPTION
This pull request resolves the issue where the faces array wasn't accessible in the hover effect JavaScript due to scope limitations. The solution ensures that the faces array is correctly passed from the Astro component to the client-side script.

closes #1 